### PR TITLE
add caching based on lat/lon with a configurable timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ When the API answers the request made by the proxy, the proxy resends the API re
 **This proxy can be hosted for free using [Netlify Functions](https://www.netlify.com/docs/functions/) with one click on the following button.**
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/tanoabeleyra/darksky-proxy)
+
+## Caching
+
+To increase performance and prevent unnecessary duplicate calls to the Dark Sky APIs, the proxy allows caching with a timeout. When the timeout (in seconds) is reached for a particular lat/lon, updated data will be retrieved from Dark Sky.
+
+To enable this feature, specify a CACHE_TIMEOUT > 0 seconds.

--- a/endpoints/forecast.js
+++ b/endpoints/forecast.js
@@ -3,9 +3,18 @@ const request = require("request-promise");
 const { API_KEY } = process.env;
 const API_URL = `https://api.darksky.net/forecast/${API_KEY}`;
 
+const cache = {};
+
 let { CORS_WHITELIST } = process.env;
 if (CORS_WHITELIST) {
   CORS_WHITELIST = CORS_WHITELIST.replace(/ /g, "").split(",");
+}
+
+let { CACHE_TIMEOUT } = process.env;
+if (!CACHE_TIMEOUT) {
+  CACHE_TIMEOUT = 0;
+} else {
+  CACHE_TIMEOUT = parseInt(CACHE_TIMEOUT, 10);
 }
 
 const getResponseHeaders = request => {
@@ -27,6 +36,23 @@ exports.handler = (event, context, callback) => {
     return;
   }
 
+  const now = Math.round(new Date().getTime() / 1000);
+
+  if (CACHE_TIMEOUT > 0) {
+    // see if we already have in the cache and the cache is < 1 hour old
+    const cachedItem = cache[`${lat},${lon}`];
+    if (!!cachedItem && now - cachedItem.time < CACHE_TIMEOUT) {
+      // console.log(`returning cached weather data for ${lat},${lon}`);
+      callback(null, {
+        body: JSON.stringify(cachedItem.response),
+        statusCode: 200,
+        headers: getResponseHeaders(event)
+      });
+      return;
+    }
+  }
+  // console.log(`fetching latest weather data for ${lat},${lon}`);
+
   const url = `${API_URL}/${lat},${lon}`;
   // Remove lat and lon parameters, they go in the URL
   delete qs.lat;
@@ -38,6 +64,12 @@ exports.handler = (event, context, callback) => {
   };
   request(url, options)
     .then(response => {
+      // cache response
+      cache[`${lat},${lon}`] = {
+        time: now,
+        response: response
+      };
+
       callback(null, {
         body: JSON.stringify(response),
         statusCode: 200,

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,4 @@
 [template.environment]
   API_KEY="Set your API key"
   CORS_WHITELIST="Optional comma-separated list of allowed cross-origin domains"
+  CACHE_TIMEOUT=3600


### PR DESCRIPTION
Was looking to prevent unnecessary lookups to the Dark Sky servers for both performance and cost reasons. For many use cases, this type of data doesn't need to be frequently updated.

FYI, from my local tests this changed the response time for cached responses from ~615ms to ~1. It's not a very robust cache, nor does it clean-up after itself atm. But given the type of data and the fact that it's optional should make it relatively safe to integrate.